### PR TITLE
Remove unused repos, install clang-8, pytest and locales

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,13 @@ RUN apt update \
 	&& apt update \
 	&& apt upgrade -y \
 	&& chmod +x debian-setup.sh \
-	&& ./debian-setup.sh -y --install-optional --install-deb-deps --install-test-deps gcc-5 g++-5 \
-		gcc-6 g++-6 gcc-7 g++-7 gcc-8 g++-8 clang-5.0 clang-6.0 clang-7 \
+	&& ./debian-setup.sh -y --install-optional --install-deb-deps --install-test-deps \
+		python3-pytest-xdist locales \
+		gcc-5 g++-5 \
+		gcc-6 g++-6 \
+		gcc-7 g++-7 \
+		gcc-8 g++-8 \
+		clang-5.0 \
+		clang-6.0 \
+		clang-7 \
 	&& rm -rf /var/lib/apt/lists/

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,8 @@ FROM ubuntu:18.04
 ADD https://raw.githubusercontent.com/wireshark/wireshark/master/tools/debian-setup.sh /
 RUN apt update \
 	&& apt install gnupg apt-utils -y \
-	&& echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic main" > /etc/apt/sources.list.d/clang.list \
-	&& echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-6.0 main" > /etc/apt/sources.list.d/clang6.list \
 	&& echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-7 main" > /etc/apt/sources.list.d/clang7.list \
+	&& echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-8 main" > /etc/apt/sources.list.d/clang8.list \
 	&& apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 6084F3CF814B57C1CF12EFD515CF4D18AF4F7421 \
 	&& apt update \
 	&& apt upgrade -y \
@@ -18,4 +17,5 @@ RUN apt update \
 		clang-5.0 \
 		clang-6.0 \
 		clang-7 \
+		clang-8 \
 	&& rm -rf /var/lib/apt/lists/


### PR DESCRIPTION
* Add python3-pytest and locales, separate packages over multiple lines
    
    pytest is used for running tests (pip is not needed), locales is needed
    to offer UTF-8 locales.

* Add clang-8, remove unused LLVM apt repos
    
    clang-5.0 and clang-6.0 are provided by Ubuntu. Additionally, remove the
    development branch repo because we do not install Clang from trunk.
---
Note: At some point we should probably remove older Clang and GCC versions as well. Testing the same compiler on different distributions is a waste of CI resources. Both the Fedora 28 and 29 jobs use GCC 8.3.1 for example, so perhaps gcc8 can be dropped (while keeping gcc8-nopcap). Just a thought.