### PR TITLE
Reduce image size, upgrade to Clang 10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM ubuntu:18.04
 ADD https://raw.githubusercontent.com/wireshark/wireshark/master/tools/debian-setup.sh /
 RUN apt-get update \
-	&& apt-get install gnupg apt-utils -y --no-install-recommends \
-	&& echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-10 main" > /etc/apt/sources.list.d/clang10.list \
+	&& apt-get install gnupg apt-utils ca-certificates -y --no-install-recommends \
+	&& echo "deb https://apt.llvm.org/bionic/ llvm-toolchain-bionic-10 main" > /etc/apt/sources.list.d/clang10.list \
 	&& apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 6084F3CF814B57C1CF12EFD515CF4D18AF4F7421 \
 	&& apt-get update \
 	&& apt-get upgrade -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,15 @@
 FROM ubuntu:18.04
 ADD https://raw.githubusercontent.com/wireshark/wireshark/master/tools/debian-setup.sh /
-RUN apt update \
-	&& apt install gnupg apt-utils -y \
-	&& echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-7 main" > /etc/apt/sources.list.d/clang7.list \
-	&& echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-8 main" > /etc/apt/sources.list.d/clang8.list \
+RUN apt-get update \
+	&& apt-get install gnupg apt-utils -y \
+	&& echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-10 main" > /etc/apt/sources.list.d/clang10.list \
 	&& apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 6084F3CF814B57C1CF12EFD515CF4D18AF4F7421 \
-	&& apt update \
-	&& apt upgrade -y \
+	&& apt-get update \
+	&& apt-get upgrade -y \
 	&& chmod +x debian-setup.sh \
 	&& ./debian-setup.sh -y --install-optional --install-deb-deps --install-test-deps \
 		python3-pytest-xdist locales \
 		gcc-5 g++-5 \
-		gcc-6 g++-6 \
-		gcc-7 g++-7 \
 		gcc-8 g++-8 \
-		clang-5.0 \
-		clang-6.0 \
-		clang-7 \
-		clang-8 \
+		clang-10 \
 	&& rm -rf /var/lib/apt/lists/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,14 @@
 FROM ubuntu:18.04
 ADD https://raw.githubusercontent.com/wireshark/wireshark/master/tools/debian-setup.sh /
 RUN apt-get update \
-	&& apt-get install gnupg apt-utils -y \
+	&& apt-get install gnupg apt-utils -y --no-install-recommends \
 	&& echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-10 main" > /etc/apt/sources.list.d/clang10.list \
 	&& apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 6084F3CF814B57C1CF12EFD515CF4D18AF4F7421 \
 	&& apt-get update \
 	&& apt-get upgrade -y \
 	&& chmod +x debian-setup.sh \
 	&& ./debian-setup.sh -y --install-optional --install-deb-deps --install-test-deps \
+		--no-install-recommends build-essential fakeroot \
 		python3-pytest-xdist locales \
 		gcc-5 g++-5 \
 		gcc-8 g++-8 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,6 @@ RUN apt-get update \
 	&& ./debian-setup.sh -y --install-optional --install-deb-deps --install-test-deps \
 		--no-install-recommends build-essential fakeroot \
 		python3-pytest-xdist locales \
-		gcc-5 g++-5 \
-		gcc-8 g++-8 \
+		gcc-7 g++-7 \
 		clang-10 \
 	&& rm -rf /var/lib/apt/lists/


### PR DESCRIPTION
Changes:

* Remove old compilers, add Clang 10

  GCC 6, 7, and Clang 5, 6, 7 are no longer needed since
  https://code.wireshark.org/review/36281
  ("gitlab-ci: remove unnecessary jobs, upgrade versions").

  Install Clang 10 as it is about to reach stable very soon. This will
  require another Wireshark .gitlab-ci.yaml change once the image is
  published.

  This reduces the image size from 2.76G to 1.75G.

  Replace apt by apt-get since 'apt' does not have a stable interface.

* Do not install recommended packages

  Reduces the Docker image size from 1.75G to 1.37G.
___
Note: I tested this image locally and was able to build a Debian package and run pytest.